### PR TITLE
Use Source object as parameter for LoaderError

### DIFF
--- a/DependencyInjection/FindComponentsPass.php
+++ b/DependencyInjection/FindComponentsPass.php
@@ -78,11 +78,13 @@ class FindComponentsPass implements CompilerPassInterface
      */
     private function ensureComponentIsDefinedInFile($componentName, $file, $templateReference): void
     {
-        if (preg_match("/{%\s+component\s+$componentName\s+{/", file_get_contents($file->getRealPath())) <= 0) {
+        $contents = file_get_contents($file->getRealPath());
+
+        if (preg_match("/{%\s+component\s+$componentName\s+{/", $contents) <= 0) {
             throw new LoaderError(
                 sprintf('Template "%s" does not contain a definition for component "%s"',
                     $templateReference, $componentName),
-                1, $templateReference);
+                1, new Source($contents, $templateReference, $file));
         }
     }
 }


### PR DESCRIPTION
Twig 3 enforces the `Source` typing on its `LoaderError` constructor, which causes the following exception in case a Twig file does not contain a valid component definition:

```
TypeError:
Argument 3 passed to Twig\Error\Error::__construct() must be an instance of Twig\Source or null, string given, called in /foo/bar/vendor/redant/twig-components-bundle/DependencyInjection/FindComponentsPass.php on line 83

  at /foo/bar/vendor/twig/twig/src/Error/Error.php:56
  at Twig\Error\Error->__construct('Template "@DesignSystem/components/badge.html.twig" does not contain a definition for component "badge"', 1, '@DesignSystem/components/badge.html.twig')
     (/foo/bar/vendor/redant/twig-components-bundle/DependencyInjection/FindComponentsPass.php:83)
```

This PR wraps the data in a proper `Source` object, resulting in the desired exception:

```
Twig\Error\LoaderError:
Template "@DesignSystem/components/badge.html.twig" does not contain a definition for component "badge"

  at /foo/bar/src/Resources/views/components/badge.html.twig:1
  at RedAnt\TwigComponentsBundle\DependencyInjection\FindComponentsPass->ensureComponentIsDefinedInFile('badge', object(SplFileInfo), '@DesignSystem/components/badgel.twig')
     (/foo/bar/vendor/redant/twig-components-bundle/DependencyInjection/FindComponentsPass.php:64)
``` 