### PR TITLE
Added missing use statement

### DIFF
--- a/DependencyInjection/FindComponentsPass.php
+++ b/DependencyInjection/FindComponentsPass.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Finder\Finder;
 use Twig\Error\LoaderError;
 use Twig\Loader\FilesystemLoader;
+use Twig\Source;
 
 class FindComponentsPass implements CompilerPassInterface
 {


### PR DESCRIPTION
It seems we missed the `use` statement in #4 while prepping for the PR 😮 @ricohumme note that `1.0.1` now throws a 'class not found' error in case the compiler pass can't find a proper component definition.